### PR TITLE
Allow purely local subgraphs

### DIFF
--- a/gateway/get-all-subgraph-info.js
+++ b/gateway/get-all-subgraph-info.js
@@ -118,7 +118,7 @@ export async function GetSDLFromStudio() {
 
   const subgraphs = {
     useFromStudio: [],
-    local: [],
+    local: config.replacedServices,
   };
 
   services.map((service) => {
@@ -126,9 +126,7 @@ export async function GetSDLFromStudio() {
       .map((s) => s.name)
       .indexOf(service.name);
 
-    if (indexOfReplacement > -1) {
-      subgraphs.local.push(config.replacedServices[indexOfReplacement]);
-    } else {
+    if (indexOfReplacement === -1) {
       subgraphs.useFromStudio.push({
         name: service.name,
         url: service.url,

--- a/gateway/get-all-subgraph-info.js
+++ b/gateway/get-all-subgraph-info.js
@@ -121,7 +121,7 @@ export async function GetSDLFromStudio() {
     local: config.replacedServices,
   };
 
-  services.map((service) => {
+  services.forEach((service) => {
     const indexOfReplacement = config.replacedServices
       .map((s) => s.name)
       .indexOf(service.name);

--- a/gateway/get-all-subgraph-info.js
+++ b/gateway/get-all-subgraph-info.js
@@ -68,7 +68,7 @@ async function loadServicesFromRemoteEndpoint({
           return {
             name,
             url,
-            sld: data._service.sdl,
+            sdl: data._service.sdl,
           };
         }
 
@@ -130,7 +130,7 @@ export async function GetSDLFromStudio() {
       subgraphs.useFromStudio.push({
         name: service.name,
         url: service.url,
-        sld: service.activePartialSchema.sdl,
+        sdl: service.activePartialSchema.sdl,
       });
     }
   });

--- a/gateway/get-fed1-schema.js
+++ b/gateway/get-fed1-schema.js
@@ -3,10 +3,10 @@ import { buildComposedSchema } from '@apollo/query-planner-1';
 import { parse } from 'graphql';
 
 export async function composeWithResolvedConfig(subgraphs) {
-  const serviceList = subgraphs.map(({ name, url, sld }) => ({
+  const serviceList = subgraphs.map(({ name, url, sdl }) => ({
     name,
     url: url ?? undefined,
-    typeDefs: parse(sld),
+    typeDefs: parse(sdl),
   }));
 
   const result = composeAndValidate(serviceList);

--- a/gateway/get-fed2-schema.js
+++ b/gateway/get-fed2-schema.js
@@ -13,7 +13,7 @@ async function composeWithResolvedConfig(graphs) {
       const subgraph = buildSubgraph(
         graph.name,
         graph.url ?? 'http://localhost:4001',
-        graph.sld
+        graph.sdl
       );
       subgraphs.add(subgraph);
     } catch (e) {


### PR DESCRIPTION
I tweaked the logic for populating the local subgraphs array. This has the side effect of allowing local subgraphs that _aren
't published to the supergraph_. That way I can test how a local subgraph composes together into my supergraph without ever deploying anything.

I can break this into several PRs if desired, since I did some minor cleaning while I was in there!